### PR TITLE
Fix for #5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 
-version = "1.0.4"
+version = "1.0.5"
 group = "team.thegoldenhoe.cameraobscura" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "CameraObscura"
 

--- a/src/main/java/team/thegoldenhoe/cameraobscura/Info.java
+++ b/src/main/java/team/thegoldenhoe/cameraobscura/Info.java
@@ -8,7 +8,7 @@ public class Info {
 
 	public static final String NAME = "Camera Obscura";
 
-	public static final String VERSION = "1.0.4";
+	public static final String VERSION = "1.0.5";
 
 	public static final String CLIENT_PROXY = "team.thegoldenhoe.cameraobscura.client.ClientProxy";
 

--- a/src/main/java/team/thegoldenhoe/cameraobscura/common/network/PhotoDataHandler.java
+++ b/src/main/java/team/thegoldenhoe/cameraobscura/common/network/PhotoDataHandler.java
@@ -19,6 +19,8 @@ import javax.imageio.ImageIO;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.management.PlayerList;
 import net.minecraft.world.World;
 import net.minecraftforge.common.DimensionManager;
 import team.thegoldenhoe.cameraobscura.CSModelMetadata;
@@ -112,7 +114,9 @@ public class PhotoDataHandler {
 				return;
 			}
 
-			EntityPlayer player = world.getPlayerEntityByUUID(photographerUUID);
+			MinecraftServer server = world.getMinecraftServer();
+			PlayerList playerList = server.getPlayerList();
+			EntityPlayer player = playerList.getPlayerByUUID(photographerUUID);
 
 			if (player == null) {
 				messageBuffer.remove(uuid);

--- a/src/main/java/team/thegoldenhoe/cameraobscura/common/network/PhotoDataHandler.java
+++ b/src/main/java/team/thegoldenhoe/cameraobscura/common/network/PhotoDataHandler.java
@@ -109,6 +109,7 @@ public class PhotoDataHandler {
 			if (photographerUUID == null) {
 				messageBuffer.remove(uuid);
 				System.err.println("Photographer UUID is null, which means we can't produce an item. Sorry :(");
+				return;
 			}
 
 			EntityPlayer player = world.getPlayerEntityByUUID(photographerUUID);
@@ -116,6 +117,7 @@ public class PhotoDataHandler {
 			if (player == null) {
 				messageBuffer.remove(uuid);
 				System.err.println("Photographer player is null, which means we can't produce an item. Sorry :(");
+				return;
 			}
 
 			ItemStack stack = player.getHeldItemMainhand();
@@ -126,6 +128,7 @@ public class PhotoDataHandler {
 			if (stack.isEmpty()) {
 				messageBuffer.remove(uuid);
 				System.err.println("Camera is null, which means we don't know how to produce the item properly. Sorry :(");
+				return;
 			}
 
 			String savePath = saveImage(createImageFromBytes(bytes));


### PR DESCRIPTION
Added some `return`s after the errors to prevent crashes when the errors occur. Changed the player lookup   to occur across all worlds on server, allowing photos to be taken in the Nether and other dimensions. Tested in the Overworld and the Nether.